### PR TITLE
fixed module to go-rspamd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module rspamd-go
+module go-rspamd
 
-go 1.15
+go 1.16
 
 require (
 	github.com/go-resty/resty/v2 v2.6.0


### PR DESCRIPTION
- should be `go-rspamd`, not `rspamd-go`
- should be `go 1.16`