### PR TITLE
Determine whether spam or ham messages have already been learned.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,6 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v1
+        with:
+          go-version: "1.16.x"
       - run: go mod tidy
       - run: git diff --exit-code -- go.mod go.sum
 

--- a/client.go
+++ b/client.go
@@ -169,3 +169,10 @@ func IsNotFound(err error) bool {
 	var errResp *errUnexpectedResponse
 	return errors.As(err, &errResp) && errResp.Status == http.StatusNotFound
 }
+
+// IsAlreadyLearnedError returns true if a request returns 208, which can happen if rspamd detects a message has already been learned as SPAM/HAM.
+// This can allow clients to gracefully handle this use case.
+func IsAlreadyLearnedError(err error) bool {
+	var errResp *errUnexpectedResponse
+	return errors.As(err, &errResp) && errResp.Status == http.StatusAlreadyReported
+}


### PR DESCRIPTION
Give clients of the library the means to gracefully handle the http status 208 which is returned when rspamd detects a message has already been learned.