### PR TITLE
Weight input as integer

### DIFF
--- a/client.go
+++ b/client.go
@@ -129,8 +129,8 @@ func (c *client) makeEmailRequest(ctx context.Context, e *Email) *resty.Request 
 	if e.options.flag != 0 {
 		headers["Flag"] = fmt.Sprintf("%d", e.options.flag)
 	}
-	if e.options.weight != 0.0 {
-		headers["Weight"] = fmt.Sprintf("%f", e.options.weight)
+	if e.options.weight != 0 {
+		headers["Weight"] = fmt.Sprintf("%d", e.options.weight)
 	}
 	return c.client.R().
 		SetContext(ctx).

--- a/email.go
+++ b/email.go
@@ -15,7 +15,7 @@ type Email struct {
 // Options encapsulate headers the client can pass in requests to rspamd.
 type Options struct {
 	flag   int
-	weight float64
+	weight int32
 }
 
 // SymbolData encapsulates the data returned for each symbol from Check.
@@ -58,7 +58,7 @@ func (e *Email) Flag(flag int) *Email {
 
 // Weight attaches a weight to an Email, and eventually as a header when sent to rspamd.
 // Weight is added to hashes.
-func (e *Email) Weight(weight float64) *Email {
+func (e *Email) Weight(weight int32) *Email {
 	e.options.weight = weight
 	return e
 }


### PR DESCRIPTION
The `Weight` header option is [parsed as a long](https://github.com/rspamd/rspamd/blob/8f9e6acda8c899ddef44bb5559a08b79287a5155/src/plugins/fuzzy_check.c#L3566-L3573). I first noticed this when seeing the error log `fuzzy_controller_handler: error converting numeric argument 1.0`.

Instead, accept an `int32` and send that. This is a breaking change.