### PR TITLE
Add user header

### DIFF
--- a/client.go
+++ b/client.go
@@ -126,6 +126,9 @@ func (c *client) makeEmailRequest(ctx context.Context, e *Email) *resty.Request 
 	if e.queueID != "" {
 		headers["Queue-ID"] = e.queueID
 	}
+	if e.user != "" {
+		headers["User"] = e.user
+	}
 	if e.options.flag != 0 {
 		headers["Flag"] = fmt.Sprintf("%d", e.options.flag)
 	}

--- a/email.go
+++ b/email.go
@@ -9,6 +9,7 @@ import (
 type Email struct {
 	message io.Reader
 	queueID string
+	user    string
 	options Options
 }
 

--- a/email.go
+++ b/email.go
@@ -50,6 +50,12 @@ func (e *Email) QueueID(queueID string) *Email {
 	return e
 }
 
+// User attaches a username for authenticated SMTP client to an Email, and eventually as a header when sent to rspamd.
+func (e *Email) User(user string) *Email {
+	e.user = user
+	return e
+}
+
 // Flag attaches a flag to an Email, and eventually as a header when sent to rspamd.
 // Flag identifies fuzzy storage.
 func (e *Email) Flag(flag int) *Email {


### PR DESCRIPTION
Added username for authenticated SMTP client header support. See https://rspamd.com/doc/architecture/protocol.html#rspamd-protocol-encryption