### PR TITLE
Update default branch references to main

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,7 +4,7 @@ on:
     tags:
       - v*
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:

--- a/dev.yml
+++ b/dev.yml
@@ -19,4 +19,4 @@ commands:
     run: go mod tidy
 
 open:
-  devbuddy: https://github.com/devbuddy/devbuddy/blob/master/docs/Config.md#config-devyml
+  devbuddy: https://github.com/devbuddy/devbuddy/blob/main/docs/Config.md#config-devyml


### PR DESCRIPTION
Related to https://github.com/Shopify/services/issues/5863

- update references to default branch to `main`